### PR TITLE
Alternative product text in different H4 tag

### DIFF
--- a/includes/wc-class-dp-discontinued-product.php
+++ b/includes/wc-class-dp-discontinued-product.php
@@ -300,6 +300,13 @@ if ( ! class_exists( 'WC_Class_DP_Discontinued_Product' ) ) {
 		 */
 		public function exclude_discontinued_products( $query ) {
 			$ids_to_hide = false;
+			
+			// ALSO HIDE ON PRODUCT TAG PAGES
+			$q_object = get_queried_object();
+			if (isset($q_object->taxonomy) && $q_object->taxonomy == 'product_tag'){
+				$ids_to_hide = $this->hide_from_shop;
+			}
+			
 			if ( $query->is_post_type_archive( 'product' ) || isset( $query->query_vars['product_cat'] ) ) {
 				$ids_to_hide = $this->hide_from_shop;
 			}

--- a/includes/wc-class-dp-discontinued-product.php
+++ b/includes/wc-class-dp-discontinued-product.php
@@ -299,23 +299,15 @@ if ( ! class_exists( 'WC_Class_DP_Discontinued_Product' ) ) {
 		 * @param object $query Main WP Query.
 		 */
 		public function exclude_discontinued_products( $query ) {
-			$ids_to_hide = false;
-			
-			// ALSO HIDE ON PRODUCT TAG PAGES
-			$q_object = get_queried_object();
-			if (isset($q_object->taxonomy) && $q_object->taxonomy == 'product_tag'){
-				$ids_to_hide = $this->hide_from_shop;
-			}
-			
-			if ( $query->is_post_type_archive( 'product' ) || isset( $query->query_vars['product_cat'] ) ) {
-				$ids_to_hide = $this->hide_from_shop;
-			}
-			if ( is_search() ) {
-				$ids_to_hide = $this->hide_from_search;
-			}
 			if ( ! is_admin() && ! $this->doing_dp_ids && $query->is_main_query() && ! is_single() && $ids_to_hide ) {
-
-				$query->set( 'post__not_in', $ids_to_hide );
+				$args = array(
+					'meta_query' => array(
+						array(
+							'key' => '_is_discontinued',
+							'compare' => 'NOT EXISTS'
+						)
+					));
+				$query->set('meta_query', $args);
 			}
 			return $query;
 		}

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'dp_alt_products_notice' ) ) {
 		$alt_option       = get_option( 'dc_alt_text' );
 		$text             = dp_alt_products_text( $prod_text_option, $text_option, __( 'This product has been discontinued.', 'woocommerce-discontinued-products' ) );
 		$alt              = dp_alt_products_text( $prod_alt_option, $alt_option, __( 'You may be interested in:', 'woocommerce-discontinued-products' ) );
-		$notice           = $no_alt ? $text : $text . ' ' . $alt;
+		$notice           = $no_alt ? $text : $text . '</H4><h4 class="discontinued-notice-alt">' . $alt . </4>;
 		return $notice;
 	}
 }

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -113,12 +113,16 @@ if ( ! function_exists( 'discontinued_template_loop_price' ) ) {
 
 	/**
 	 * Discontinued_template_loop_price - replaces price with discontinued text.
+	 * Replaces price in admin with "discontinued".
 	 *
 	 * @return null
 	 */
 	function discontinued_template_loop_price( $price, $product ) {
 		$product_id = $product->get_id();
 		if ( dp_is_discontinued( $product_id ) ) {
+			if(is_admin()){
+				return 'Discontinued';
+			}
 			$prod_text_option = get_post_meta( $product_id, '_discontinued_product_text', true );
 			$text_option      = get_option( 'dc_discontinued_text' );
 			$text             = dp_alt_products_text( $prod_text_option, $text_option, __( 'This product has been discontinued.', 'woocommerce-discontinued-products' ) );

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'dp_alt_products' ) ) {
 		$alt_products = is_array( $alt_products ) ? $alt_products : array();
 		$notice       = dp_alt_products_notice( $post->ID, empty( $alt_products ) );
 		?>
-		<h4 class="discontinued-notice"><?php echo esc_html( $notice ); ?></h4>
+		<?php echo $notice; ?></h4>
 		<?php
 		foreach ( $alt_products as $alt_product ) {
 			?>
@@ -70,7 +70,7 @@ if ( ! function_exists( 'dp_alt_products_notice' ) ) {
 		$alt_option       = get_option( 'dc_alt_text' );
 		$text             = dp_alt_products_text( $prod_text_option, $text_option, __( 'This product has been discontinued.', 'woocommerce-discontinued-products' ) );
 		$alt              = dp_alt_products_text( $prod_alt_option, $alt_option, __( 'You may be interested in:', 'woocommerce-discontinued-products' ) );
-		$notice           = $no_alt ? $text : $text . '</H4><h4 class="discontinued-notice-alt">' . $alt . </4>;
+		$notice           = $no_alt ? '<h4 class="discontinued-notice">' . esc_html($text) . '</H4>' : '<h4 class="discontinued-notice">' . esc_html($text) . '</H4><h4 class="discontinued-notice-alt">' . esc_html($alt) . '</H4>';
 		return $notice;
 	}
 }


### PR DESCRIPTION
I did not like the fact that the Alternative product text was in the same line, and just was basically the same as the Display text.
So I changed the output a little. A second H4 is created with a different class.