### PR TITLE
Fix: Fatal error when exporting products. String was treated as array.

### DIFF
--- a/includes/class-dp-csv-import-export.php
+++ b/includes/class-dp-csv-import-export.php
@@ -152,8 +152,9 @@ if ( ! class_exists( 'DP_CSV_Import_Export' ) ) {
 		 * @return mixed     $value   Should be in a format that can be output into a text file (string, numeric, etc).
 		 */
 		public function add_export_data_alt_products( $value, $product ) {
-			$value = $product->get_meta( '_alt_products', true, 'edit' );
-			return implode( ', ', $value );
+			$meta_data = $product->get_meta( '_alt_products', false, 'edit' );
+			$values = wp_list_pluck( $meta_data, 'value' );
+			return implode( ', ', $values );
 		}
 
 		/**


### PR DESCRIPTION
`WC_Product->get_meta()` was being called with `single` true where an array of `_alt_products` was expected. Then that single string was being passed to `implode()`, rather than an array as expected.


```
Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /path/to/wp-content/plugins/woocommerce-discontinued-products/includes/class-dp-csv-import-export.php:156
Stack trace:
#0 /path/to/wp-content/plugins/woocommerce-discontinued-products/includes/class-dp-csv-import-export.php(156): implode(', ', '')
#1 /path/to/wp-includes/class-wp-hook.php(309): DP_CSV_Import_Export->add_export_data_alt_products('', Object(WC_Product_Simple))
#2 /path/to/wp-includes/plugin.php(191): WP_Hook->apply_filters('', Array)
#3 /path/to/wp-content/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php(232): apply_filters('woocommerce_pro...', '', Object(WC_Product_Simple), 'alt_products')
#4 /path/to/wp-content/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php(185): WC_Product_CSV_Exporter->generate_row_data(Object(WC_Product_Simple))
#5 /path/to/wp-content/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php(117): WC_Product_CSV_Exporter->prepare_data_to_export()
#6 /path/to/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-exporters.php(165): WC_CSV_Batch_Exporter->generate_file()
#7 /path/to/wp-includes/class-wp-hook.php(307): WC_Admin_Exporters->do_ajax_product_export('')
#8 /path/to/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#9 /path/to/wp-includes/plugin.php(476): WP_Hook->do_action(Array)
#10 /path/to/wp-admin/admin-ajax.php(187): do_action('wp_ajax_woocomm...')
#11 {main}
  thrown
```